### PR TITLE
revise integration method with sidekiq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-cronitor (2.0.0)
+    sidekiq-cronitor (3.0.0)
       cronitor (~> 4.0)
       sidekiq (~> 6.0)
 
@@ -10,19 +10,19 @@ GEM
   specs:
     bump (0.10.0)
     connection_pool (2.2.5)
-    cronitor (4.0.0)
+    cronitor (4.1.2)
       httparty
     diff-lcs (1.3)
-    httparty (0.18.1)
+    httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
+    mime-types-data (3.2022.0105)
     multi_xml (0.6.0)
     rack (2.2.3)
     rake (13.0.1)
-    redis (4.2.5)
+    redis (4.6.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -36,7 +36,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    sidekiq (6.2.1)
+    sidekiq (6.4.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)

--- a/lib/sidekiq/cronitor/version.rb
+++ b/lib/sidekiq/cronitor/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Cronitor
-    VERSION = '2.0.0'
+    VERSION = '3.0.0'
   end
 end

--- a/spec/sidekiq/cronitor_spec.rb
+++ b/spec/sidekiq/cronitor_spec.rb
@@ -1,9 +1,97 @@
-RSpec.describe Sidekiq::Cronitor do
+class DummyWorker
+  attr_accessor :sidekiq_options
+
+  def sidekiq_options
+    @sidekiq_options ||= {}
+  end
+end
+
+RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
   it "has a version number" do
     expect(Sidekiq::Cronitor::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  let(:worker) { DummyWorker.new }
+  describe "#cronitor" do
+    it 'should return a Cronitor Monitor' do
+      expect(subject.send(:cronitor, worker)).to be_a Cronitor::Monitor
+    end
+  end
+
+  describe "#cronitor_disabled?" do
+    context "no option is set" do
+      it "should return true" do
+        expect(subject.send(:cronitor_disabled?, worker)).to be false
+      end
+    end
+    context "option is set to false" do
+      before(:each) do
+        worker.sidekiq_options = { "cronitor" => { disabled: false } }
+      end
+      it "should return false" do
+        expect(subject.send(:cronitor_disabled?, worker)).to be false
+      end
+    end
+    context "option is set to true" do
+      before(:each) do
+        worker.sidekiq_options = { "cronitor" => { disabled: true } }
+      end
+      it "should return true" do
+        expect(subject.send(:cronitor_disabled?, worker)).to be true
+      end
+    end
+  end
+
+  describe "#job_key" do
+    context "with no explicit key defined" do
+      it "should use the class name as the key" do
+        expect(subject.send(:job_key, worker)).to eq worker.class.name
+      end
+    end
+
+    context "with an explicit key defined" do
+      before(:each) do
+        worker.sidekiq_options = { "cronitor" => { key: "explicit_key_name" } }
+      end
+
+      it "should use the key as the job_key" do
+        expect(subject.send(:job_key, worker)).to eq "explicit_key_name"
+      end
+    end
+  end
+
+  describe "#should_ping?" do
+    context "without an api key" do
+      it "should be false" do
+        expect(subject.send(:cronitor, worker).api_key).to be_nil
+        expect(subject.send(:should_ping?, worker)).to be false
+      end
+    end
+    context "with an api key" do
+      before(:all) do
+        Cronitor.api_key = "fake_key"
+      end
+      context "with the disable option not set" do
+        it "should be true" do
+          expect(subject.send(:should_ping?, worker)).to be true
+        end
+      end
+      context "with the disable option set to true" do
+        before(:each) do
+          worker.sidekiq_options = { "cronitor" => { disabled: true } }
+        end
+        it "should return false" do
+          expect(subject.send(:should_ping?, worker)).to be false
+        end
+      end
+      context "with the disable option set to false" do
+        before(:each) do
+          worker.sidekiq_options = { "cronitor" => { disabled: false } }
+        end
+        it "should return true" do
+          expect(subject.send(:should_ping?, worker)).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
* allow the user to add the middleware to sidekiq in the order they see fit
* update the middleware name to differentiate from a potential future client middleware
* make sure the logger uses the job key name if user specified
* allow the users to opt out of middleware telemetry on specific jobs
* make sure the integration will work in a pure ruby environment for those sidekiq users who aren't using a rails app
* add some basic specs to cover all the helper methods
* updated README instructions to reflect updated integration method