### PR TITLE
use top level sidekiq_options keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ Optional: You can specify the monitor key directly using `sidekiq_options`:
 ```ruby
 class MyJob
   include Sidekiq::Job
-
-  # note that 'key' should be set with a symbol as the key in the hash
-  sidekiq_options cronitor: { key: 'abc123' }
+  sidekiq_options cronitor_key: 'abc123'
 
   def perform
   end
@@ -73,14 +71,29 @@ To disable Cronitor for a specific job you can set the following option:
 ```ruby
 class MyJob
   include Sidekiq::Job
-
-  # note that 'disabled' should be set with a symbol as the key in the hash
-  sidekiq_options cronitor: { disabled: true }
+  sidekiq_options cronitor_disabled: true
 
   def perform
   end
 end
 ```
+
+## Disabling For Some Jobs
+If you have an entire group or category of jobs you wish to disable monitoring on, it's easiest to create a base class with that option set and then have all your jobs inherit from that base class.
+
+```ruby
+  class UnmonitoredJob
+    include Sidekiq::Job
+    sidekiq_options cronitor_disabled: true
+  end
+
+  class NoInstrumentationJob < UnmonitoredJob
+    def perform
+    end
+  end
+```
+
+Note: Do NOT set a cronitor_key option on your base class or all your inherited jobs will report under the same job in Cronitor.
 
 ## Development
 

--- a/lib/sidekiq/cronitor.rb
+++ b/lib/sidekiq/cronitor.rb
@@ -24,15 +24,23 @@ module Sidekiq::Cronitor
     end
 
     def cronitor_disabled?(worker)
-      options(worker).fetch(:disabled, false)
+      disabled = worker.class.sidekiq_options.fetch(:cronitor_disabled, nil)
+      if disabled.nil?
+        options(worker).fetch(:disabled, false)
+      else
+        !!disabled
+      end
     end
 
     def job_key(worker)
+      worker.class.sidekiq_options.fetch(:cronitor_key, nil) ||
       options(worker).fetch(:key, worker.class.name)
     end
 
     def options(worker)
-      opts = worker.class.sidekiq_options.fetch('cronitor', {})
+      # eventually we will delete this method of passing options
+      # ultimately we want all cronitor options to be top level keys
+      opts = worker.class.sidekiq_options.fetch(:cronitor, {})
       # symbolize_keys is a rails helper, so only use it if it's defined
       opts = opts.symbolize_keys if opts.respond_to?(:symbolize_keys)
       opts

--- a/lib/sidekiq/cronitor/version.rb
+++ b/lib/sidekiq/cronitor/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Cronitor
-    VERSION = '3.0.0'
+    VERSION = '3.1.0'
   end
 end

--- a/spec/sidekiq/cronitor_spec.rb
+++ b/spec/sidekiq/cronitor_spec.rb
@@ -1,8 +1,13 @@
 class DummyWorker
-  attr_accessor :sidekiq_options
-
-  def sidekiq_options
+  def self.sidekiq_options=(options)
     @sidekiq_options ||= {}
+    @sidekiq_options.merge!(options)
+  end
+  def self.sidekiq_options
+    @sidekiq_options ||= {}
+  end
+  def self.reset_options
+    @sidekiq_options = {}
   end
 end
 
@@ -12,6 +17,10 @@ RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
   end
 
   let(:worker) { DummyWorker.new }
+  before(:each) do
+    worker.class.reset_options
+  end
+
   describe "#cronitor" do
     it 'should return a Cronitor Monitor' do
       expect(subject.send(:cronitor, worker)).to be_a Cronitor::Monitor
@@ -20,23 +29,48 @@ RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
 
   describe "#cronitor_disabled?" do
     context "no option is set" do
-      it "should return true" do
-        expect(subject.send(:cronitor_disabled?, worker)).to be false
-      end
-    end
-    context "option is set to false" do
-      before(:each) do
-        worker.sidekiq_options = { "cronitor" => { disabled: false } }
-      end
       it "should return false" do
+        expect(worker.class.sidekiq_options).to be_empty
         expect(subject.send(:cronitor_disabled?, worker)).to be false
       end
     end
-    context "option is set to true" do
-      before(:each) do
-        worker.sidekiq_options = { "cronitor" => { disabled: true } }
+
+    context "option is set with deprecated method" do
+      context "option is set to false" do
+        it "should return false" do
+          worker.class.sidekiq_options = { :cronitor => { disabled: false } }
+          expect(subject.send(:cronitor_disabled?, worker)).to be false
+        end
       end
+      context "option is set to true" do
+        it "should return true" do
+          worker.class.sidekiq_options = { :cronitor => { disabled: true } }
+          expect(subject.send(:cronitor_disabled?, worker)).to be true
+        end
+      end
+    end
+
+    context "top level option supercedes deprecated method" do
+      it "should return true when set" do
+        worker.class.sidekiq_options = { :cronitor => { disabled: false }, :cronitor_disabled => true }
+        expect(subject.send(:cronitor_disabled?, worker)).to be true
+      end
+      it "should return false when set" do
+        worker.class.sidekiq_options = { :cronitor => { disabled: true }, :cronitor_disabled => false }
+        expect(subject.send(:cronitor_disabled?, worker)).to be false
+      end
+    end
+
+    context "option is set to false" do
+      it "should return false" do
+        worker.class.sidekiq_options = { cronitor_disabled: false }
+        expect(subject.send(:cronitor_disabled?, worker)).to be false
+      end
+    end
+
+    context "option is set to true" do
       it "should return true" do
+        worker.class.sidekiq_options = { cronitor_disabled: true }
         expect(subject.send(:cronitor_disabled?, worker)).to be true
       end
     end
@@ -45,17 +79,31 @@ RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
   describe "#job_key" do
     context "with no explicit key defined" do
       it "should use the class name as the key" do
+        expect(worker.class.sidekiq_options).to be_empty
         expect(subject.send(:job_key, worker)).to eq worker.class.name
       end
     end
 
     context "with an explicit key defined" do
-      before(:each) do
-        worker.sidekiq_options = { "cronitor" => { key: "explicit_key_name" } }
+      context "with deprecated options" do
+        it "should use the key as the job_key" do
+          worker.class.sidekiq_options = { :cronitor => { key: "explicit_key_name" } }
+          expect(subject.send(:job_key, worker)).to eq "explicit_key_name"
+        end
       end
 
-      it "should use the key as the job_key" do
-        expect(subject.send(:job_key, worker)).to eq "explicit_key_name"
+      context "with both options set" do
+        it "should supercede deprecated method" do
+          worker.class.sidekiq_options = { :cronitor => { key: "explicit_key_name" }, :cronitor_key => "other_name" }
+          expect(subject.send(:job_key, worker)).to eq "other_name"
+        end
+      end
+
+      context "with top level key set" do
+        it "should use the key as the job_key" do
+          worker.class.sidekiq_options = { cronitor_key: "explicit_key_name2" }
+          expect(subject.send(:job_key, worker)).to eq "explicit_key_name2"
+        end
       end
     end
   end
@@ -67,28 +115,29 @@ RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
         expect(subject.send(:should_ping?, worker)).to be false
       end
     end
+
     context "with an api key" do
       before(:all) do
         Cronitor.api_key = "fake_key"
       end
+
       context "with the disable option not set" do
         it "should be true" do
+          expect(worker.class.sidekiq_options).to be_empty
           expect(subject.send(:should_ping?, worker)).to be true
         end
       end
+
       context "with the disable option set to true" do
-        before(:each) do
-          worker.sidekiq_options = { "cronitor" => { disabled: true } }
-        end
         it "should return false" do
+          worker.class.sidekiq_options = { cronitor_disabled: true }
           expect(subject.send(:should_ping?, worker)).to be false
         end
       end
+
       context "with the disable option set to false" do
-        before(:each) do
-          worker.sidekiq_options = { "cronitor" => { disabled: false } }
-        end
         it "should return true" do
+          worker.class.sidekiq_options = { cronitor_disabled: false }
           expect(subject.send(:should_ping?, worker)).to be true
         end
       end


### PR DESCRIPTION
- bump version number to reflect change in parameters
- maintains backward compatibility with old options
- old options should be dropped at next major version bump
- updated README to reflect how to stop instrumentation on large groups of jobs
- updated specs to reflect changes
- fixed a few typos / bugs