### PR TITLE
make scheduled jobs sync available to apps

### DIFF
--- a/lib/sidekiq/cronitor.rb
+++ b/lib/sidekiq/cronitor.rb
@@ -3,6 +3,14 @@ require 'cronitor'
 
 require 'sidekiq/cronitor/version'
 
+if defined? SidekiqScheduler
+  require 'sidekiq/cronitor/sidekiq_scheduler'
+end
+
+if defined? Sidekiq::Periodic
+  require 'sidekiq/cronitor/periodic_jobs'
+end
+
 module Sidekiq::Cronitor
   class ServerMiddleware
     def call(worker, message, queue)

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -1,0 +1,14 @@
+module Sidekiq::Cronitor
+  class PeriodicJobs
+    def self.sync_schedule!
+      monitors_payload = []
+      loops = Sidekiq::Periodic::LoopSet.new
+      loops.each do |lop|
+        job_key = lop.klass.sidekiq_options.fetch("cronitor_key", nil) || lop.klass.to_s
+        cronitor_disabled = lop.klass.sidekiq_options.fetch("cronitor_disabled", false)
+        monitors_payload << {key: job_key, schedule: lop.schedule, metadata: lop.options, platform: 'sidekiq', type: 'job' } unless cronitor_disabled
+      end
+      Cronitor::Monitor.put(monitors: monitors_payload)
+    end
+  end
+end

--- a/lib/sidekiq/cronitor/sidekiq_scheduler.rb
+++ b/lib/sidekiq/cronitor/sidekiq_scheduler.rb
@@ -1,0 +1,21 @@
+module Sidekiq::Cronitor
+  class SidekiqScheduler
+    def self.sync_schedule!
+      monitors_payload = []
+      # go through the scheduled jobs and find cron defined ones
+      Sidekiq.get_schedule.each do |k, v|
+        # make sure the job has a cron or every definition, we skip non cron/every defined jobs for now
+        if !v["cron"].nil? || !v["every"].nil?
+          schedule = v["cron"] || v["every"]
+          # just in case an explicit job key has been set
+          job_klass = Object.const_get(v["class"])
+          job_key = job_klass.sidekiq_options.fetch("cronitor_key", nil) || v["class"]
+          # if monitoring for this job is turned off
+          cronitor_disabled = job_klass.sidekiq_options.fetch("cronitor_disabled", false)
+          monitors_payload << {key: job_key.to_s, schedule: schedule, platform: 'sidekiq', type: 'job' } unless cronitor_disabled
+        end
+      end
+      Cronitor::Monitor.put(monitors: monitors_payload)
+    end
+  end
+end

--- a/lib/tasks/periodic_jobs.rake
+++ b/lib/tasks/periodic_jobs.rake
@@ -8,14 +8,7 @@ namespace :cronitor do
   namespace :sidekiq_periodic_jobs do
     desc 'Upload Sidekiq Pro Periodic Jobs to Cronitor'
     task :sync => :environment do
-      monitors_payload = []
-      loops = Sidekiq::Periodic::LoopSet.new
-      loops.each do |lop|
-        job_key = lop.klass.sidekiq_options.fetch("cronitor_key", nil) || lop.klass.to_s
-        cronitor_disabled = lop.klass.sidekiq_options.fetch("cronitor_disabled", false)
-        monitors_payload << {key: job_key, schedule: lop.schedule, metadata: lop.options, platform: 'sidekiq', type: 'job' } unless cronitor_disabled
-      end
-      Cronitor::Monitor.put(monitors: monitors_payload)
+      Sidekiq::Cronitor::PeriodicJobs.sync_schedule!
     end
   end
 end

--- a/lib/tasks/sidekiq_scheduler.rake
+++ b/lib/tasks/sidekiq_scheduler.rake
@@ -6,21 +6,7 @@ namespace :cronitor do
     desc 'Upload Sidekiq Scheduler Cron Jobs to Cronitor'
     # uses the Rails environment because we constantize the class to read the sidekiq_options
     task :sync => :environment do
-      monitors_payload = []
-      # go through the scheduled jobs and find cron defined ones
-      Sidekiq.get_schedule.each do |k, v|
-        # make sure the job has a cron definition, we skip non cron defined jobs for now
-        unless v["cron"].nil?
-          # just in case an explicit job key has been set
-          job_klass = Object.const_get(v["class"])
-          job_key = job_klass.sidekiq_options.fetch("cronitor_key", nil) || v["class"]
-          # if monitoring for this job is turned off
-          cronitor_disabled = job_klass.sidekiq_options.fetch("cronitor_disabled", false)
-          monitors_payload << {key: job_key.to_s, schedule: v["cron"], platform: 'sidekiq', type: 'job' } unless cronitor_disabled
-        end
-      end
-
-      Cronitor::Monitor.put(monitors: monitors_payload)
+      Sidekiq::Cronitor::SidekiqScheduler.sync_schedule!
     end
   end
 end


### PR DESCRIPTION
* move sync code from rake task to classes
* load classes if plugins are detected
* update rake tasks to call class method code
* support both cron and every syntax on sidekiq_scheduler (every syntax support may be rough)