### PR TITLE
Rescue Cronitor::Error during sync_schedule!

### DIFF
--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -1,14 +1,22 @@
-module Sidekiq::Cronitor
-  class PeriodicJobs
-    def self.sync_schedule!
-      monitors_payload = []
-      loops = Sidekiq::Periodic::LoopSet.new
-      loops.each do |lop|
-        job_key = lop.klass.sidekiq_options.fetch("cronitor_key", nil) || lop.klass.to_s
-        cronitor_disabled = lop.klass.sidekiq_options.fetch("cronitor_disabled", false)
-        monitors_payload << {key: job_key, schedule: lop.schedule, metadata: lop.options, platform: 'sidekiq', type: 'job' } unless cronitor_disabled
+# frozen_string_literal: true
+
+module Sidekiq
+  module Cronitor
+    class PeriodicJobs
+      def self.sync_schedule!
+        monitors_payload = []
+        loops = Sidekiq::Periodic::LoopSet.new
+        loops.each do |lop|
+          job_key = lop.klass.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
+          next if lop.klass.sidekiq_options.fetch('cronitor_disabled', false)
+
+          monitors_payload << { key: job_key, schedule: lop.schedule, metadata: lop.options, platform: 'sidekiq', type: 'job' }
+        end
+
+        Cronitor::Monitor.put(monitors: monitors_payload)
+      rescue Cronitor::Error => e
+        Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
       end
-      Cronitor::Monitor.put(monitors: monitors_payload)
     end
   end
 end

--- a/lib/sidekiq/cronitor/sidekiq_scheduler.rb
+++ b/lib/sidekiq/cronitor/sidekiq_scheduler.rb
@@ -1,21 +1,27 @@
-module Sidekiq::Cronitor
-  class SidekiqScheduler
-    def self.sync_schedule!
-      monitors_payload = []
-      # go through the scheduled jobs and find cron defined ones
-      Sidekiq.get_schedule.each do |k, v|
-        # make sure the job has a cron or every definition, we skip non cron/every defined jobs for now
-        if !v["cron"].nil? || !v["every"].nil?
-          schedule = v["cron"] || v["every"]
+# frozen_string_literal: true
+
+module Sidekiq
+  module Cronitor
+    class SidekiqScheduler
+      def self.sync_schedule!
+        monitors_payload = []
+        # go through the scheduled jobs and find cron defined ones
+        Sidekiq.get_schedule.each do |_k, v|
+          # make sure the job has a cron or every definition, we skip non cron/every defined jobs for now
+          next unless (schedule = v['cron'] || v['every'])
+
           # just in case an explicit job key has been set
-          job_klass = Object.const_get(v["class"])
-          job_key = job_klass.sidekiq_options.fetch("cronitor_key", nil) || v["class"]
-          # if monitoring for this job is turned off
-          cronitor_disabled = job_klass.sidekiq_options.fetch("cronitor_disabled", false)
-          monitors_payload << {key: job_key.to_s, schedule: schedule, platform: 'sidekiq', type: 'job' } unless cronitor_disabled
+          job_klass = Object.const_get(v['class'])
+          job_key = job_klass.sidekiq_options.fetch('cronitor_key', v['class'])
+          next if job_klass.sidekiq_options.fetch('cronitor_disabled', false)
+
+          monitors_payload << { key: job_key.to_s, schedule: schedule, platform: 'sidekiq', type: 'job' }
         end
+
+        Cronitor::Monitor.put(monitors: monitors_payload)
+      rescue Cronitor::Error => e
+        Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
       end
-      Cronitor::Monitor.put(monitors: monitors_payload)
     end
   end
 end


### PR DESCRIPTION
Adding this to a shared gem, and want to make sure `sync_schedule!` can be called without blowing up.