### PR TITLE
Fix namespacing

### DIFF
--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
-module Sidekiq
-  module Cronitor
-    class PeriodicJobs
-      def self.sync_schedule!
-        monitors_payload = []
-        loops = Sidekiq::Periodic::LoopSet.new
-        loops.each do |lop|
-          job_key = lop.klass.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
-          next if lop.klass.sidekiq_options.fetch('cronitor_disabled', false)
+module Sidekiq::Cronitor
+  class PeriodicJobs
+    def self.sync_schedule!
+      monitors_payload = []
+      loops = Sidekiq::Periodic::LoopSet.new
+      loops.each do |lop|
+        job_key = lop.klass.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
+        next if lop.klass.sidekiq_options.fetch('cronitor_disabled', false)
 
-          monitors_payload << { key: job_key, schedule: lop.schedule, metadata: lop.options, platform: 'sidekiq', type: 'job' }
-        end
-
-        Cronitor::Monitor.put(monitors: monitors_payload)
-      rescue Cronitor::Error => e
-        Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
+        monitors_payload << { key: job_key, schedule: lop.schedule, metadata: lop.options, platform: 'sidekiq', type: 'job' }
       end
+
+      Cronitor::Monitor.put(monitors: monitors_payload)
+    rescue Cronitor::Error => e
+      Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
     end
   end
 end

--- a/lib/sidekiq/cronitor/sidekiq_scheduler.rb
+++ b/lib/sidekiq/cronitor/sidekiq_scheduler.rb
@@ -1,27 +1,25 @@
 # frozen_string_literal: true
 
-module Sidekiq
-  module Cronitor
-    class SidekiqScheduler
-      def self.sync_schedule!
-        monitors_payload = []
-        # go through the scheduled jobs and find cron defined ones
-        Sidekiq.get_schedule.each do |_k, v|
-          # make sure the job has a cron or every definition, we skip non cron/every defined jobs for now
-          next unless (schedule = v['cron'] || v['every'])
+module Sidekiq::Cronitor
+  class SidekiqScheduler
+    def self.sync_schedule!
+      monitors_payload = []
+      # go through the scheduled jobs and find cron defined ones
+      Sidekiq.get_schedule.each do |_k, v|
+        # make sure the job has a cron or every definition, we skip non cron/every defined jobs for now
+        next unless (schedule = v['cron'] || v['every'])
 
-          # just in case an explicit job key has been set
-          job_klass = Object.const_get(v['class'])
-          job_key = job_klass.sidekiq_options.fetch('cronitor_key', v['class'])
-          next if job_klass.sidekiq_options.fetch('cronitor_disabled', false)
+        # just in case an explicit job key has been set
+        job_klass = Object.const_get(v['class'])
+        job_key = job_klass.sidekiq_options.fetch('cronitor_key', v['class'])
+        next if job_klass.sidekiq_options.fetch('cronitor_disabled', false)
 
-          monitors_payload << { key: job_key.to_s, schedule: schedule, platform: 'sidekiq', type: 'job' }
-        end
-
-        Cronitor::Monitor.put(monitors: monitors_payload)
-      rescue Cronitor::Error => e
-        Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
+        monitors_payload << { key: job_key.to_s, schedule: schedule, platform: 'sidekiq', type: 'job' }
       end
+
+      Cronitor::Monitor.put(monitors: monitors_payload)
+    rescue Cronitor::Error => e
+      Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
     end
   end
 end

--- a/spec/sidekiq/cronitor/periodic_jobs_spec.rb
+++ b/spec/sidekiq/cronitor/periodic_jobs_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'sidekiq/cronitor/periodic_jobs'
+
+RSpec.describe Sidekiq::Cronitor::PeriodicJobs do
+  before do
+    allow(Sidekiq::Periodic::LoopSet).to receive(:new).and_return([])
+  end
+
+  describe '.sync_schedule!' do
+    xit { expect { described_class.sync_schedule! }.not_to raise_error }
+  end
+end

--- a/spec/sidekiq/cronitor/sidekiq_scheduler_spec.rb
+++ b/spec/sidekiq/cronitor/sidekiq_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'sidekiq/cronitor/sidekiq_scheduler'
+
+RSpec.describe Sidekiq::Cronitor::SidekiqScheduler do
+  before do
+    allow(Sidekiq).to receive(:get_schedule).and_return([])
+  end
+
+  describe '.sync_schedule!' do
+    xit { expect { described_class.sync_schedule! }.not_to raise_error }
+  end
+end


### PR DESCRIPTION
```
> Sidekiq::Cronitor::PeriodicJobs.sync_schedule!
NameError: uninitialized constant Sidekiq::Cronitor::Error
```

The nested modules actually broke this - sorry @aflanagan 😢 . You're gonna wanna pull 3.2

Reverted the nesting and tested locally. Tried to add specs, but I can't figure out how to stub those constants.