### PR TITLE
Sidekiq::PeriodicJob sync_schedule enhancements

### DIFF
--- a/lib/sidekiq/cronitor.rb
+++ b/lib/sidekiq/cronitor.rb
@@ -41,8 +41,18 @@ module Sidekiq::Cronitor
     end
 
     def job_key(worker)
-      worker.class.sidekiq_options.fetch("cronitor_key", nil) ||
-      options(worker).fetch(:key, worker.class.name)
+      periodic_job_key(worker) || worker.class.sidekiq_options.fetch('cronitor_key', nil) ||
+        options(worker).fetch(:key, worker.class.name)
+    end
+
+    def periodic_job_key(worker)
+      return unless defined?(Sidekiq::Periodic)
+
+      periodic_job = Sidekiq::Periodic::LoopSet.new.find do |lop|
+        lop.history.find { |j| j[0] == worker.jid }
+      end
+
+      periodic_job.present? && periodic_job.options.fetch('cronitor_key', nil)
     end
 
     def options(worker)

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -6,10 +6,10 @@ module Sidekiq::Cronitor
       monitors_payload = []
       loops = Sidekiq::Periodic::LoopSet.new
       loops.each do |lop|
-        job_key = lop.klass.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
-        next if lop.klass.sidekiq_options.fetch('cronitor_disabled', false)
+        job_key = lop.klass.constantize.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
+        next if lop.klass.constantize.sidekiq_options.fetch('cronitor_disabled', false)
 
-        monitors_payload << { key: job_key, schedule: lop.schedule, metadata: lop.options, platform: 'sidekiq', type: 'job' }
+        monitors_payload << { key: job_key, schedule: lop.schedule, metadata: lop.options.to_s, platform: 'sidekiq', type: 'job' }
       end
 
       Cronitor::Monitor.put(monitors: monitors_payload)

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -6,7 +6,9 @@ module Sidekiq::Cronitor
       monitors_payload = []
       loops = Sidekiq::Periodic::LoopSet.new
       loops.each do |lop|
-        job_key = lop.klass.constantize.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
+        job_key = lop.options.fetch('cronitor_key', false) ||
+                  lop.klass.constantize.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
+
         next if lop.klass.constantize.sidekiq_options.fetch('cronitor_disabled', false)
 
         monitors_payload << { key: job_key, schedule: lop.schedule, metadata: lop.options.to_s, platform: 'sidekiq', type: 'job' }

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -11,7 +11,14 @@ module Sidekiq::Cronitor
 
         next if lop.klass.constantize.sidekiq_options.fetch('cronitor_disabled', false)
 
-        monitors_payload << { key: job_key, schedule: lop.schedule, metadata: lop.options.to_s, platform: 'sidekiq', type: 'job' }
+        monitors_payload << {
+          key: job_key,
+          schedule: lop.schedule,
+          timezone: lop.tz_name || Time.respond_to?(:zone) && Time.zone.tzinfo.name || nil,
+          metadata: lop.options.to_s,
+          platform: 'sidekiq',
+          type: 'job'
+        }
       end
 
       Cronitor::Monitor.put(monitors: monitors_payload)

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -6,24 +6,28 @@ module Sidekiq::Cronitor
       monitors_payload = []
       loops = Sidekiq::Periodic::LoopSet.new
       loops.each do |lop|
-        job_key = lop.options.fetch('cronitor_key', false) ||
-                  lop.klass.constantize.sidekiq_options.fetch('cronitor_key', lop.klass.to_s)
-
-        next if lop.klass.constantize.sidekiq_options.fetch('cronitor_disabled', false)
+        next if fetch_option(lop, 'cronitor_disabled')
 
         monitors_payload << {
-          key: job_key,
+          key: fetch_option(lop, 'cronitor_key') || lop.klass.to_s,
+          group: fetch_option(lop, 'cronitor_group'),
+          grace_seconds: fetch_option(lop, 'cronitor_grace_seconds')&.to_i,
           schedule: lop.schedule,
           timezone: lop.tz_name || Time.respond_to?(:zone) && Time.zone.tzinfo.name || nil,
           metadata: lop.options.to_s,
           platform: 'sidekiq',
           type: 'job'
-        }
+        }.compact
       end
 
       Cronitor::Monitor.put(monitors: monitors_payload)
     rescue Cronitor::Error => e
       Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
+    end
+
+    def self.fetch_option(lop, key)
+      lop.options.fetch(key, nil) ||
+        lop.klass.constantize.sidekiq_options.fetch(key, nil)
     end
   end
 end


### PR DESCRIPTION
## Overview
I have made a few fixes and enhancements to the Sidekiq::PeriodicJob extension, and have bundled them into a single PR. Happy to test other parts of the integration with Sidekiq Enterprise if needed 🙂

## Constantize loopset class 
I found when using the Sidekiq Periodic Jobs feature, the sync_schedule! feature does not seem to work. The job class on Sidekiq::Periodic::LoopSet is a string rather than a constant, therefore I have constantized it before calling the sidekiq_options method and this seems to have fixed the integration.

## Add cronitor_key, cronior_grace_seconds, cronitor_group options
This allows passing in `cronitor_key`, `cronitor_grace_seconds`, and `cronitor_group` in the Sidekiq periodic jobs list:

```
mgr.register('* * * * *', 'MyPeriodicJob', cronitor_key: 'My Periodic Job', cronitor_grace_seconds: 120, cronitor_group: 'periodic')
```

## Include timezone
Sidekiq::PeriodicJob has an option for passing in a different timezone for a job. This supports it, and will fall back on the server timezone if not present.