### PR TITLE
Support sidekiq 6 or 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 PATH
   remote: .
   specs:
-    sidekiq-cronitor (3.5.0)
+    sidekiq-cronitor (3.6.0)
       cronitor (~> 5.0)
-      sidekiq (~> 6.0)
+      sidekiq (< 8)
 
 GEM
   remote: https://rubygems.org/
   specs:
     bump (0.10.0)
-    connection_pool (2.2.5)
+    concurrent-ruby (1.2.0)
+    connection_pool (2.3.0)
     cronitor (5.0.0)
       httparty
     diff-lcs (1.3)
@@ -18,9 +19,10 @@ GEM
       multi_xml (>= 0.5.2)
     mini_mime (1.1.2)
     multi_xml (0.6.0)
-    rack (2.2.6.2)
+    rack (3.0.4.1)
     rake (13.0.1)
-    redis (4.7.1)
+    redis-client (0.12.1)
+      connection_pool
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -34,10 +36,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    sidekiq (6.5.4)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.5.0)
+    sidekiq (7.0.3)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
 
 PLATFORMS
   ruby

--- a/lib/sidekiq/cronitor/version.rb
+++ b/lib/sidekiq/cronitor/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Cronitor
-    VERSION = '3.5.0'
+    VERSION = '3.6.0'
   end
 end

--- a/sidekiq-cronitor.gemspec
+++ b/sidekiq-cronitor.gemspec
@@ -5,8 +5,8 @@ require "sidekiq/cronitor/version"
 Gem::Specification.new do |spec|
   spec.name          = "sidekiq-cronitor"
   spec.version       = Sidekiq::Cronitor::VERSION
-  spec.authors       = ["Zeke Gabrielse", "Samuel Cochran"]
-  spec.email         = ["zeke@keygen.sh", "sj26@sj26.com"]
+  spec.authors       = ["Zeke Gabrielse", "Samuel Cochran", "Kevin Tom", "August Flanagan"]
+  spec.email         = ["zeke@keygen.sh", "sj26@sj26.com", "kevin.tom@gmail.com", "august@cronitor.io"]
 
   spec.summary       = %q{Monitor your Sidekiq jobs with Cronitor}
   spec.description   = %q{Integrates Sidekiq with Cronitor so that workers send lifecycle events - run/complete/fail - around their perform methods}
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["README.md", "LICENSE", "lib/**/*.rb"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", "~> 6.0"
+  spec.add_dependency "sidekiq", "< 8"
   spec.add_dependency "cronitor", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
@ezekg I took a look at these [two](https://www.mikeperham.com/2022/10/27/introducing-sidekiq-7.0/) [guides](https://github.com/mperham/sidekiq/blob/main/docs/7.0-Upgrade.md) by Mike, and I don't think there is anything we need to do to this library other than modify the dependency version to allow for either 6 or 7. 

Let me know if you could test out this branch! 🙏 