### PR TITLE
Fix bug where _enabled: false could still be enabled

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,8 @@ on:
     branches:
       - master
     paths:
-      - /lib/**
-      - /spec/**
+      - /lib/**/*
+      - /spec/**/*
       - /Gemfile.lock
       - /*.gemspec
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,11 +5,6 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - /lib/**/*
-      - /spec/**/*
-      - /Gemfile.lock
-      - /*.gemspec
 
 name: Tests
 jobs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-cronitor (3.7.0)
+    sidekiq-cronitor (3.7.1)
       cronitor (~> 5.1)
       sidekiq (< 8)
 

--- a/lib/sidekiq/cronitor.rb
+++ b/lib/sidekiq/cronitor.rb
@@ -33,7 +33,7 @@ module Sidekiq::Cronitor
     end
 
     def cronitor_disabled?(worker)
-      if worker.class.sidekiq_options["cronitor_enabled"]
+      if worker.class.sidekiq_options.has_key?("cronitor_enabled")
         !worker.class.sidekiq_options.fetch("cronitor_enabled", Cronitor.auto_discover_sidekiq)
       else
         worker.class.sidekiq_options.fetch("cronitor_disabled", options(worker).fetch(:disabled, !Cronitor.auto_discover_sidekiq))

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -6,7 +6,7 @@ module Sidekiq::Cronitor
       monitors_payload = []
       loops = Sidekiq::Periodic::LoopSet.new
       loops.each do |lop|
-        if fetch_option(lop, 'cronitor_enabled')
+        if lop.options.has_key?('cronitor_enabled') || lop.klass.constantize.sidekiq_options.has_key?('cronitor_enabled')
           next unless fetch_option(lop, 'cronitor_enabled', Cronitor.auto_discover_sidekiq)
         else
           next if fetch_option(lop, 'cronitor_disabled', !Cronitor.auto_discover_sidekiq)

--- a/lib/sidekiq/cronitor/sidekiq_scheduler.rb
+++ b/lib/sidekiq/cronitor/sidekiq_scheduler.rb
@@ -13,7 +13,7 @@ module Sidekiq::Cronitor
         job_klass = Object.const_get(v['class'])
         job_key = job_klass.sidekiq_options.fetch('cronitor_key', v['class'])
 
-        if job_klass.sidekiq_options['cronitor_enabled']
+        if job_klass.sidekiq_options.has_key?('cronitor_enabled')
           next unless job_klass.sidekiq_options.fetch('cronitor_enabled', Cronitor.auto_discover_sidekiq)
         else
           next if job_klass.sidekiq_options.fetch('cronitor_disabled', !Cronitor.auto_discover_sidekiq)

--- a/lib/sidekiq/cronitor/version.rb
+++ b/lib/sidekiq/cronitor/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Cronitor
-    VERSION = '3.7.0'
+    VERSION = '3.7.1'
   end
 end


### PR DESCRIPTION
```rb
if worker.class.sidekiq_options["cronitor_enabled"]
```

can be false, and fall into the else condition, which would default to `!Cronitor.auto_discover_sidekiq`, which defaults to true... so disabled = !true = false.

Also... pathing wasn't working for unknown reasons. Removed ¯\\\_(ツ)_/¯. Specs are fast anyway, so not needed.