### PR TITLE
Use job payload instead of worker instance in middleware

### DIFF
--- a/lib/sidekiq/cronitor.rb
+++ b/lib/sidekiq/cronitor.rb
@@ -13,72 +13,63 @@ end
 
 module Sidekiq::Cronitor
   class ServerMiddleware
-    def call(worker, message, queue)
-      ping(worker: worker, state: 'run')
+    # @param [Object] worker the instance of the job that was queued
+    # @param [Hash] job_payload the full job payload
+    #   * @see https://github.com/sidekiq/sidekiq/wiki/Job-Format
+    # @param [String] queue the name of the queue the job was pulled from
+    # @yield the next middleware in the chain or worker `perform` method
+    def call(worker, job_payload, queue)
+      ping(job_payload: job_payload, state: 'run')
 
       result = yield
     rescue => e
-      ping(worker: worker, state: 'fail', message: e.to_s)
+      ping(job_payload: job_payload, state: 'fail', message: e.to_s)
 
       raise e
     else
-      ping(worker: worker, state: 'complete')
+      ping(job_payload: job_payload, state: 'complete')
       result # to be consistent with client middleware, return results of yield
     end
 
     private
 
-    def cronitor(worker)
-      Cronitor::Monitor.new(job_key(worker))
+    def cronitor(job_payload)
+      Cronitor::Monitor.new(job_key(job_payload))
     end
 
-    def cronitor_disabled?(worker)
-      if worker.class.sidekiq_options.has_key?("cronitor_enabled")
-        !worker.class.sidekiq_options.fetch("cronitor_enabled", Cronitor.auto_discover_sidekiq)
+    def cronitor_disabled?(job_payload)
+      if job_payload.has_key?("cronitor_enabled")
+        !job_payload.fetch("cronitor_enabled", Cronitor.auto_discover_sidekiq)
       else
-        worker.class.sidekiq_options.fetch("cronitor_disabled", options(worker).fetch(:disabled, !Cronitor.auto_discover_sidekiq))
+        job_payload.fetch("cronitor_disabled", options(job_payload).fetch("disabled", !Cronitor.auto_discover_sidekiq))
       end
     end
 
-    def job_key(worker)
-      periodic_job_key(worker) || worker.class.sidekiq_options.fetch('cronitor_key', nil) ||
-        options(worker).fetch(:key, worker.class.name)
+    def job_key(job_payload)
+      job_payload['cronitor_key'] || options(job_payload)['key'] || job_payload['class']
     end
 
-    def periodic_job_key(worker)
-      return unless defined?(Sidekiq::Periodic)
-
-      periodic_job = Sidekiq::Periodic::LoopSet.new.find do |lop|
-        lop.history.find { |j| j[0] == worker.jid }
-      end
-
-      periodic_job.present? && periodic_job.options.fetch('cronitor_key', nil)
-    end
-
-    def options(worker)
+    def options(job_payload)
       # eventually we will delete this method of passing options
       # ultimately we want all cronitor options to be top level keys
-      opts = worker.class.sidekiq_options.fetch("cronitor", {})
-      # symbolize_keys is a rails helper, so only use it if it's defined
-      opts = opts.symbolize_keys if opts.respond_to?(:symbolize_keys)
-      opts
+      job_payload.fetch("cronitor", {})
     end
 
-    def ping(worker:, state:, message: nil)
-      return unless should_ping?(worker)
+    def ping(job_payload:, state:, message: nil)
+      return unless should_ping?(job_payload)
 
-      Sidekiq.logger.debug("[cronitor] ping: worker=#{job_key(worker)} state=#{state} message=#{message}")
+      Sidekiq.logger.debug("[cronitor] ping: worker=#{job_key(job_payload)} state=#{state} message=#{message}")
 
-      cronitor(worker).ping(state: state, message: message)
+      cronitor(job_payload).ping(state: state, message: message)
     rescue Cronitor::Error => e
-      Sidekiq.logger.error("[cronitor] error during ping: worker=#{job_key(worker)} error=#{e.message}")
+      Sidekiq.logger.error("[cronitor] error during ping: worker=#{job_key(job_payload)} error=#{e.message}")
     rescue => e
-      Sidekiq.logger.error("[cronitor] unexpected error: worker=#{job_key(worker)} error=#{e.message}")
+      Sidekiq.logger.error("[cronitor] unexpected error: worker=#{job_key(job_payload)} error=#{e.message}")
       Sidekiq.logger.error(e.backtrace.first)
     end
 
-    def should_ping?(worker)
-      !cronitor(worker).api_key.nil? && !cronitor_disabled?(worker)
+    def should_ping?(job_payload)
+      !cronitor(job_payload).api_key.nil? && !cronitor_disabled?(job_payload)
     end
   end
 end

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -6,7 +6,7 @@ module Sidekiq::Cronitor
       monitors_payload = []
       loops = Sidekiq::Periodic::LoopSet.new
       loops.each do |lop|
-        if lop.options.has_key?('cronitor_enabled') || lop.klass.constantize.sidekiq_options.has_key?('cronitor_enabled')
+        if parsed_options(lop).has_key?('cronitor_enabled') || Object.const_get(lop.klass).sidekiq_options.has_key?('cronitor_enabled')
           next unless fetch_option(lop, 'cronitor_enabled', Cronitor.auto_discover_sidekiq)
         else
           next if fetch_option(lop, 'cronitor_disabled', !Cronitor.auto_discover_sidekiq)
@@ -29,9 +29,17 @@ module Sidekiq::Cronitor
       Sidekiq.logger.error("[cronitor] error during #{name}.#{__method__}: #{e}")
     end
 
+    def self.parsed_options(lop)
+      if lop.options.is_a?(String)
+        JSON.parse(lop.options)
+      else
+        lop.options
+      end
+    end
+
     def self.fetch_option(lop, key, default = nil)
-      lop.options.fetch(key, default) ||
-        lop.klass.constantize.sidekiq_options.fetch(key, default)
+      parsed_options(lop).fetch(key, default) ||
+        Object.const_get(lop.klass).sidekiq_options.fetch(key, default)
     end
   end
 end

--- a/spec/sidekiq/cronitor/periodic_jobs_spec.rb
+++ b/spec/sidekiq/cronitor/periodic_jobs_spec.rb
@@ -2,12 +2,70 @@
 
 require 'sidekiq/cronitor/periodic_jobs'
 
+class DummyWorker
+  def self.sidekiq_options=(options)
+    @sidekiq_options ||= {}
+    @sidekiq_options.merge!(options)
+  end
+  def self.sidekiq_options
+    @sidekiq_options ||= {}
+  end
+  def self.reset_options
+    @sidekiq_options = {}
+  end
+end
+
 RSpec.describe Sidekiq::Cronitor::PeriodicJobs do
+  let(:cronitor_key) { "dummy-worker" }
+  let(:loops) { [job] }
+
   before do
-    allow(Sidekiq::Periodic::LoopSet).to receive(:new).and_return([])
+    class_double("Sidekiq::Periodic::LoopSet").as_stubbed_const
+    allow(Sidekiq::Periodic::LoopSet).to receive(:new).and_return(loops)
   end
 
   describe '.sync_schedule!' do
-    xit { expect { described_class.sync_schedule! }.not_to raise_error }
+    context "when no loops" do
+      let(:loops) { [] }
+      it { expect { described_class.sync_schedule! }.not_to raise_error }
+    end
+
+    context "when job options are stringified JSON" do
+      let(:job) {
+        instance_double(
+          "Sidekiq::Periodic::Loop",
+          klass: DummyWorker.name,
+          schedule: "* * * * *",
+          tz_name: "Etc/UTC",
+          options: {
+            "cronitor_key" => cronitor_key,
+            "cronitor_group" => "dummy-team"
+          }.to_json
+        )
+      }
+      it "updates monitors" do
+        expect(Cronitor::Monitor).to receive(:put).with(monitors: [hash_including(key: cronitor_key)])
+        described_class.sync_schedule!
+      end
+    end
+
+    context "when job options are a hash" do
+      let(:job) {
+        instance_double(
+          "Sidekiq::Periodic::Loop",
+          klass: DummyWorker.name,
+          schedule: "* * * * *",
+          tz_name: "Etc/UTC",
+          options: {
+            "cronitor_key" => cronitor_key,
+            "cronitor_group" => "dummy-team"
+          }
+        )
+      }
+      it "updates monitors" do
+        expect(Cronitor::Monitor).to receive(:put).with(monitors: [hash_including(key: cronitor_key)])
+        described_class.sync_schedule!
+      end
+    end
   end
 end

--- a/spec/sidekiq/cronitor_spec.rb
+++ b/spec/sidekiq/cronitor_spec.rb
@@ -1,92 +1,89 @@
-class DummyWorker
-  def self.sidekiq_options=(options)
-    @sidekiq_options ||= {}
-    @sidekiq_options.merge!(options)
-  end
-  def self.sidekiq_options
-    @sidekiq_options ||= {}
-  end
-  def self.reset_options
-    @sidekiq_options = {}
-  end
-end
-
 RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
   it "has a version number" do
     expect(Sidekiq::Cronitor::VERSION).not_to be nil
   end
 
-  let(:worker) { DummyWorker.new }
-  before(:each) do
-    worker.class.reset_options
+  let(:job_payload) do
+    {
+      "class" => "DummyWorker",
+      "queue" => "default",
+      "args" => [],
+      "jid" => "1a3d0acfaf74d3657dece500",
+      "created_at" => 1725992760.565256,
+      "enqueued_at" => 1725992760.565299
+    }.merge(job_options)
   end
+
+  let(:job_options) { {} }
 
   describe "#cronitor" do
     it 'should return a Cronitor Monitor' do
-      expect(subject.send(:cronitor, worker)).to be_a Cronitor::Monitor
+      expect(subject.send(:cronitor, job_payload)).to be_a Cronitor::Monitor
     end
   end
 
   describe "#cronitor_disabled?" do
     context "no option is set" do
       it "should return false" do
-        expect(worker.class.sidekiq_options).to be_empty
-        expect(subject.send(:cronitor_disabled?, worker)).to be false
+        expect(subject.send(:cronitor_disabled?, job_payload)).to be false
       end
     end
 
     context "option is set with deprecated method" do
       context "option is set to false" do
+        let(:job_options) { { "cronitor" => { "disabled" => false } } }
         it "should return false" do
-          worker.class.sidekiq_options = { "cronitor" => { disabled: false } }
-          expect(subject.send(:cronitor_disabled?, worker)).to be false
+          expect(subject.send(:cronitor_disabled?, job_payload)).to be false
         end
       end
       context "option is set to true" do
+        let(:job_options) { { "cronitor" => { "disabled" => true } } }
         it "should return true" do
-          worker.class.sidekiq_options = { "cronitor" => { disabled: true } }
-          expect(subject.send(:cronitor_disabled?, worker)).to be true
+          expect(subject.send(:cronitor_disabled?, job_payload)).to be true
         end
       end
     end
 
     context "top level option supercedes deprecated method" do
-      it "should return true when set" do
-        worker.class.sidekiq_options = { "cronitor" => { disabled: false }, "cronitor_disabled" => true }
-        expect(subject.send(:cronitor_disabled?, worker)).to be true
+      context "when true" do
+        let(:job_options) { { "cronitor" => { "disabled" => false }, "cronitor_disabled" => true } }
+        it "should return true" do
+          expect(subject.send(:cronitor_disabled?, job_payload)).to be true
+        end
       end
-      it "should return false when set" do
-        worker.class.sidekiq_options = { "cronitor" => { disabled: true }, "cronitor_disabled" => false }
-        expect(subject.send(:cronitor_disabled?, worker)).to be false
+      context "when false" do
+        let(:job_options) { { "cronitor" => { "disabled" => true }, "cronitor_disabled" => false } }
+        it "should return false" do
+          expect(subject.send(:cronitor_disabled?, job_payload)).to be false
+        end
       end
     end
 
     context "option is set to false" do
+      let(:job_options) { { "cronitor_disabled" => false } }
       it "should return false" do
-        worker.class.sidekiq_options = { "cronitor_disabled" => false }
-        expect(subject.send(:cronitor_disabled?, worker)).to be false
+        expect(subject.send(:cronitor_disabled?, job_payload)).to be false
       end
     end
 
     context "option is set to true" do
+      let(:job_options) { { "cronitor_disabled" => true } }
       it "should return true" do
-        worker.class.sidekiq_options = { "cronitor_disabled" => true }
-        expect(subject.send(:cronitor_disabled?, worker)).to be true
+        expect(subject.send(:cronitor_disabled?, job_payload)).to be true
       end
     end
 
     context "cronitor_enabled is set to true" do
+      let(:job_options) { { "cronitor_enabled" => true } }
       it "should return false" do
-        worker.class.sidekiq_options = { "cronitor_enabled" => true }
-        expect(subject.send(:cronitor_disabled?, worker)).to be false
+        expect(subject.send(:cronitor_disabled?, job_payload)).to be false
       end
     end
 
     context "Cronitor.auto_discover_sidekiq is set to false" do
       it "should return true" do
         Cronitor.auto_discover_sidekiq = false
-        worker.class.sidekiq_options = {}
-        expect(subject.send(:cronitor_disabled?, worker)).to be true
+        expect(subject.send(:cronitor_disabled?, job_payload)).to be true
         Cronitor.auto_discover_sidekiq = true # reset to default
       end
     end
@@ -95,30 +92,29 @@ RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
   describe "#job_key" do
     context "with no explicit key defined" do
       it "should use the class name as the key" do
-        expect(worker.class.sidekiq_options).to be_empty
-        expect(subject.send(:job_key, worker)).to eq worker.class.name
+        expect(subject.send(:job_key, job_payload)).to eq job_payload["class"]
       end
     end
 
     context "with an explicit key defined" do
       context "with deprecated options" do
+        let(:job_options) { { "cronitor" => { "key" => "explicit_key_name" } } }
         it "should use the key as the job_key" do
-          worker.class.sidekiq_options = { "cronitor" => { key: "explicit_key_name" } }
-          expect(subject.send(:job_key, worker)).to eq "explicit_key_name"
+          expect(subject.send(:job_key, job_payload)).to eq "explicit_key_name"
         end
       end
 
       context "with both options set" do
+        let(:job_options) { { "cronitor" => { "key" => "explicit_key_name" }, "cronitor_key" => "other_name" } }
         it "should supercede deprecated method" do
-          worker.class.sidekiq_options = { "cronitor" => { key: "explicit_key_name" }, "cronitor_key" => "other_name" }
-          expect(subject.send(:job_key, worker)).to eq "other_name"
+          expect(subject.send(:job_key, job_payload)).to eq "other_name"
         end
       end
 
       context "with top level key set" do
+        let(:job_options) { { "cronitor_key" => "explicit_key_name2" } }
         it "should use the key as the job_key" do
-          worker.class.sidekiq_options = { "cronitor_key" => "explicit_key_name2" }
-          expect(subject.send(:job_key, worker)).to eq "explicit_key_name2"
+          expect(subject.send(:job_key, job_payload)).to eq "explicit_key_name2"
         end
       end
     end
@@ -127,8 +123,8 @@ RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
   describe "#should_ping?" do
     context "without an api key" do
       it "should be false" do
-        expect(subject.send(:cronitor, worker).api_key).to be_nil
-        expect(subject.send(:should_ping?, worker)).to be false
+        expect(subject.send(:cronitor, job_payload).api_key).to be_nil
+        expect(subject.send(:should_ping?, job_payload)).to be false
       end
     end
 
@@ -139,22 +135,21 @@ RSpec.describe Sidekiq::Cronitor::ServerMiddleware do
 
       context "with the disable option not set" do
         it "should be true" do
-          expect(worker.class.sidekiq_options).to be_empty
-          expect(subject.send(:should_ping?, worker)).to be true
+          expect(subject.send(:should_ping?, job_payload)).to be true
         end
       end
 
       context "with the disable option set to true" do
+        let(:job_options) { { "cronitor_disabled" => true } }
         it "should return false" do
-          worker.class.sidekiq_options = { "cronitor_disabled" => true }
-          expect(subject.send(:should_ping?, worker)).to be false
+          expect(subject.send(:should_ping?, job_payload)).to be false
         end
       end
 
       context "with the disable option set to false" do
+        let(:job_options) { { "cronitor_disabled" => false } }
         it "should return true" do
-          worker.class.sidekiq_options = { "cronitor_disabled" => false }
-          expect(subject.send(:should_ping?, worker)).to be true
+          expect(subject.send(:should_ping?, job_payload)).to be true
         end
       end
     end


### PR DESCRIPTION
I'm proposing that we drive the Sidekiq middleware off of the job payload hash instead of the worker instance.

## Why?

There are many ways to configure job options on a Sidekiq worker (See https://github.com/sidekiq/sidekiq/issues/6092#issuecomment-1788028356):
```
Sidekiq.default_job_options
sidekiq_options key: value
JobClass.set(key: value)
PeriodicManager.register(..., key: value)
```

Sidekiq merges all of these options into one payload that gets passed into middleware (as the second argument of `call()`).

In the current middleware, job options are mostly fetched via `worker.class.sidekiq_options`, which would only look at options set via `sidekiq_options` in the worker class and ignore any options set via other methods (e.g. periodic job config). Addressing this by fetching options from various places (as is done in `periodic_job_key()`) adds unnecessary work and complexity as Sidekiq already merges options from various sources into the job payload.

## What?

- Refactors the internals of the Sidekiq server middleware to use the job payload hash instead of the worker instance
- Updates specs accordingly