### PR TITLE
Add support for Sidekiq 8

### DIFF
--- a/lib/sidekiq/cronitor/version.rb
+++ b/lib/sidekiq/cronitor/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Cronitor
-    VERSION = '3.8.0'
+    VERSION = '3.9.0'
   end
 end

--- a/sidekiq-cronitor.gemspec
+++ b/sidekiq-cronitor.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["README.md", "LICENSE", "lib/**/*.rb"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", "< 8"
+  spec.add_dependency "sidekiq", "< 9"
   spec.add_dependency "cronitor", "~> 5.1"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
Doesn't look like there's anything stopping Sidekiq 8 from being used other than this version constraint.

Edit: CI is failing because this gem is including a lockfile. Most gems don't commit lockfiles.